### PR TITLE
Fix a bug list bug in interfaces

### DIFF
--- a/pywifi/pywifi.py
+++ b/pywifi/pywifi.py
@@ -20,7 +20,7 @@ class PyWiFi:
     def interfaces(self):
         """Collect the available wlan interfaces."""
 
-        __ifaces = []
+        self.__ifaces = []
 
         for interface in wifiutils.interfaces():
             iface = Interface(interface)


### PR DESCRIPTION
Interfaces returns a list that was expanding with each call. This is not the correct behavior.

This fixes it.