### PR TITLE
win: Added check for NULL SSID in scan_results()

### DIFF
--- a/pywifi/_wifiutil_win.py
+++ b/pywifi/_wifiutil_win.py
@@ -264,6 +264,7 @@ class WifiUtil():
         networks = cast(avail_network_list.contents.Network,
                      POINTER(WLAN_AVAILABLE_NETWORK))
 
+        self._logger.debug("Scan found {0} networks.".format(avail_network_list.contents.dwNumberOfItems))
         network_list = []
         for i in range(avail_network_list.contents.dwNumberOfItems):
 
@@ -271,7 +272,8 @@ class WifiUtil():
 
                 ssid = ''
                 for j in range(networks[i].dot11Ssid.uSSIDLength):
-                    ssid += "%c" % networks[i].dot11Ssid.ucSSID[j]
+                    if networks[i].dot11Ssid.ucSSID != b'':
+                        ssid += "%c" % networks[i].dot11Ssid.ucSSID[j]
 
                 bss_list = pointer(WLAN_BSS_LIST())
                 self._wlan_get_network_bss_list(self._handle,


### PR DESCRIPTION
In my area I was receiving networks with non-zero SSID length but NULL SSID strings. This change catches this condition and prevents a index out of bound exception.