### PR TITLE
Fix Issue #51 - Trailing ':' character for BSSIDs on Windows

### DIFF
--- a/pywifi/_wifiutil_win.py
+++ b/pywifi/_wifiutil_win.py
@@ -299,6 +299,7 @@ class WifiUtil():
                     network.bssid = ''
                     for k in range(6):
                         network.bssid += "%02x:" % bsses[j].dot11Bssid[k]
+                    network.bssid = network.bssid[:-1]
 
                     network.signal = bsses[j].lRssi
                     network.freq = bsses[j].ulChCenterFrequency


### PR DESCRIPTION
Issue: https://github.com/awkman/pywifi/issues/51