### PR TITLE
network_profiles() accessing dict as callable, fix

### DIFF
--- a/pywifi/_wifiutil_linux.py
+++ b/pywifi/_wifiutil_linux.py
@@ -235,7 +235,7 @@ class WifiUtil():
             else:
                 # Assume the possible ciphers TKIP and CCMP
                 if len(ciphers) == 1:
-                    network.cipher = cipher_str_to_value(ciphers[0].upper())
+                    network.cipher = cipher_str_to_value[ciphers[0].upper()]
                 elif 'CCMP' in ciphers:
                     network.cipher = CIPHER_TYPE_CCMP
 

--- a/pywifi/_wifiutil_linux.py
+++ b/pywifi/_wifiutil_linux.py
@@ -194,6 +194,14 @@ class WifiUtil():
                 continue
             else:
                 network.ssid = ssid[1:-1]
+            
+            disabled = self._send_cmd_to_wpas(
+                obj['name'],
+                'GET_NETWORK {} disabled'.format(network_id), True)
+            if ssid.upper().startswith('FAIL'):
+                continue
+            else:
+                network.disabled = int(disabled)
 
             key_mgmt = self._send_cmd_to_wpas(
                 obj['name'],

--- a/pywifi/profile.py
+++ b/pywifi/profile.py
@@ -17,6 +17,7 @@ class Profile():
         self.ssid = None
         self.bssid = None
         self.key = None
+        self.disabled = 0
 
     def process_akm(self):
 


### PR DESCRIPTION
fix for calling to interface.network_profiles() causing exception:
```
pywifi/_wifiutil_linux.py", line 239, in network_profiles
    network.cipher = cipher_str_to_value(ciphers[0].upper())
TypeError: 'dict' object is not callable
```
