### PR TITLE
Mitigate bug in wlanapi

### DIFF
--- a/pywifi/_wifiutil_win.py
+++ b/pywifi/_wifiutil_win.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # vim: set fileencoding=utf-8
 
-"""Implementations of wifi functions of Linux."""
+"""Implementations of wifi functions of Windows."""
 
 import re
 import platform
@@ -535,7 +535,7 @@ class WifiUtil():
         func.argtypes = [HANDLE, POINTER(GUID), DWORD, c_void_p, POINTER(
             POINTER(WLAN_AVAILABLE_NETWORK_LIST))]
         func.restypes = [DWORD]
-        return func(handle, iface_guid, 2, None, network_list)
+        return func(handle, iface_guid, 0, None, network_list)
 
     def _wlan_get_network_bss_list(self, handle, iface_guid, bss_list, ssid = None, security = False):
 


### PR DESCRIPTION
When connecting to wireless networks, `wlanconnect` can fail if called from a Windows service. This appears to be a bug when using network profiles with the `WLAN_PROFILE_USER` flag.

This change removes that flag to mitigate the issue.

fixes #71 

see also: https://docs.microsoft.com/en-us/answers/questions/397654/34netsh-wlan-connect34-wlanapiwlanconnect-from-wit.html